### PR TITLE
Allows for the docroot to be hidden by default and not necessary in the json.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ is the id of the of the site being looped over.
 [:sites][site_name][:drupal][:install]['--clean-url'] = 1
 
 # Set up the docroot to be used as a default
+[:sites][site_name][:drupal][:settings][:docroot] = ''
 [:sites][site_name][:drupal][:settings][:profile] = 'standard' // If action includes install, this profile will be installed.
 [:sites][site_name][:drupal][:settings][:files] = "#{docroot_before}sites/default/files" // Where the sites files live
 [:sites][site_name][:drupal][:settings][:cookbook] = 'drupal'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -58,10 +58,10 @@ node[:drupal][:sites].each do |site_name, site|
 
   #Set up the docroot to be used as a default
   default[:drupal][:sites][site_name][:drupal][:settings][:docroot] = ''
-  docroot = site[:drupal][:settings][:docroot]
   docroot_before = ''
   docoot_after = ''
-  if !docroot.empty?
+  if node[:drupal][:sites][site_name][:drupal][:settings][:docroot].to_s != ''
+    docroot = node[:drupal][:sites][site_name][:drupal][:settings][:docroot]
     docroot_before = "#{docroot}/"
     docoot_after = "/#{docroot}"
   end


### PR DESCRIPTION
Resolves #13. 

Tested on example. Please test as well. 