### PR TITLE
Add apc opscode cache.

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -3,7 +3,7 @@ site :opscode
 metadata
 
 cookbook 'apache2', '~> 1.8.14'
-cookbook 'php', '~> 1.2.6'
+cookbook 'php', '~> 1.3.10'
 cookbook 'mysql', '~> 4.0.10'
 cookbook 'database', '~> 1.5.2'
 cookbook 'ssh_known_hosts', '~> 1.1.0'

--- a/recipes/php.rb
+++ b/recipes/php.rb
@@ -1,9 +1,9 @@
 #
-# Author::  Kevin Bridges (<kevin@cyberswat.com>)
+# Author::  Alex Knoll (arknoll@gmail.com)
 # Cookbook Name:: drupal
-# Recipe:: mysql
+# Recipe:: php
 #
-# Copyright 2013, Cyberswat Industries, LLC.
+# Copyright 2015, Alex Knoll
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,10 +19,16 @@
 #
 include_recipe 'php'
 
-['php5-mysql', 'php5-gd', 'php5-curl'].each do |pkg|
+['php5-mysql', 'php5-gd', 'php5-curl', 'libpcre3-dev'].each do |pkg|
   package pkg do
     action :install
   end
+end
+
+# install apc pecl with directives.
+php_pear "apc" do
+  action :install
+  directives(:shm_size => '96M', :enable_cli => 1)
 end
 
 php_pear 'uploadprogress' do


### PR DESCRIPTION
This is pretty sweet.

I did a before and after test using drupal commons install profile and apache ab test:

sudo ab -n 10 -c 5 http://commons.local/

Before average load time was about 3000 ms.

After enabling apc average load time was about 1300 ms.

apc.stat is set to 1. Meaning, any files you change will immediately be put into the cache at the next request.

Here are all of the apc settings (because I know @chrisolof wants to know)

```
apc.cache_by_default	1
apc.canonicalize	1
apc.coredump_unmap	0
apc.enable_cli	1
apc.enabled	1
apc.file_md5	0
apc.file_update_protection	2
apc.filters	
apc.gc_ttl	3600
apc.include_once_override	0
apc.lazy_classes	0
apc.lazy_functions	0
apc.max_file_size	1M
apc.mmap_file_mask	
apc.num_files_hint	1000
apc.preload_path	
apc.report_autofilter	0
apc.rfc1867	0
apc.rfc1867_freq	0
apc.rfc1867_name	APC_UPLOAD_PROGRESS
apc.rfc1867_prefix	upload_
apc.rfc1867_ttl	3600
apc.serializer	default
apc.shm_segments	1
apc.shm_size	128M
apc.slam_defense	1
apc.stat	1
apc.stat_ctime	0
apc.ttl	0
apc.use_request_time	1
apc.user_entries_hint	4096
apc.user_ttl	0
apc.write_lock	1
```